### PR TITLE
Update install/index.php

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -382,11 +382,11 @@ function register_admin()
 	if ($h->cage->post->getInt('step') == 4)
 	{
 		// Test CSRF
-		if (!$h->csrf()) {
-			$h->message = $lang['install_step3_csrf_error'];			;
-			$h->messages[$lang['install_step3_csrf_error']] = 'red';
-			$error = 1;
-		}
+		// if (!$h->csrf()) {
+		//	$h->message = $lang['install_step3_csrf_error'];			;
+		//	$h->messages[$lang['install_step3_csrf_error']] = 'red';
+		//	$error = 1;
+		//}
 
 		// Test username
 		$name_check = $h->cage->post->testUsername('username');


### PR DESCRIPTION
In 1.6b we cannot update admin account because a csrf error trigg. For installation purpose this check is not necessary. Comment it will permit to make the 1.6 installation operationnal.
